### PR TITLE
Add a command line method for Cabal's new-repl mode

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -118,6 +118,10 @@ otherwise look for a .cabal file, or use the current dir."
                                                       '("nix-shell" "--run" (if dante-target (concat "cabal repl " dante-target) "cabal repl")))))
     (stack . ,(lambda (root) (dante-repl-by-file root '("stack.yaml") '("stack" "repl" dante-target))))
     (mafia . ,(lambda (root) (dante-repl-by-file root '("mafia") '("mafia" "repl" dante-target))))
+    (new-build . ,(lambda (root)
+                    (when (or (directory-files root nil ".*\\.cabal$")
+                              (file-exists-p "cabal.project"))
+                      '("cabal" "new-repl" dante-target))))
     (bare  . ,(lambda (_) '("cabal" "repl" dante-target))))
   "Default GHCi launch command lines.")
 


### PR DESCRIPTION
This adds an entry to `dante-repl-command-line-default-methods` that attempts to use Cabal's `new-repl` feature associated with its newer [Nix-style package building system](http://blog.ezyang.com/2016/05/announcing-cabal-new-build-nix-style-local-builds/). I've tested this with a handful of my projects on which I use `new-build` and things seem to work fine for my use-cases, but I haven't put it through a _lot_ of heavy lifting, and there may be edge-cases I haven't yet found.

I also confess that I'm not entirely sure if all the logic here is necessary—and, if it is, whether it should be factored into a helper function like `dante-repl-by-glob` or something—but I'd be happy to make changes of that sort.