### PR TITLE
Copy some company-mode code from Intero

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -395,6 +395,35 @@ CHECKER and BUFFER are added to each item parsed from STRING."
   "In BUFFER, call FUNC with ARGS."
   (with-current-buffer buffer (apply func args)))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Company integration (auto-completion)
+
+(defun company-dante (command &optional arg &rest ignored)
+  "Company source for dante, with the standard COMMAND and ARG args.
+Other arguments are IGNORED."
+  (interactive (list 'interactive))
+  (cl-case command
+    (interactive (company-begin-backend 'company-dante))
+    (prefix (current-word))
+    (candidates
+     (unless (eq (dante-state) 'dead)
+       (cons :async
+             (-partial 'dante-get-repl-completions
+                       (current-buffer)
+                       (current-word)))))))
+
+(defun dante-get-repl-completions (source-buffer prefix cont)
+  "Get REPL completions and send to SOURCE-BUFFER.
+Completions for PREFIX are passed to CONT in SOURCE-BUFFER."
+  (dante-cps-let ((reply (dante-async-call (format ":complete repl %S" prefix))))
+    (with-current-buffer
+        source-buffer
+      (funcall
+       cont
+       (mapcar
+        (lambda (x)
+          (replace-regexp-in-string "\\\"" "" x))
+        (cdr (split-string reply "\n" t)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Source buffer operations


### PR DESCRIPTION
Does some stuff if I manually call company-dante while writing some code.

---

Can someone test this out? I'm wondering if the Haskell Spacemacs layer doesn't have Company configured correctly.