### PR TITLE
Run haskell-mode without any hooks

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -211,12 +211,15 @@ You can use this to kill them or look inside."
   "Return a haskell-fontified version of EXPRESSION.
 If `haskell-mode' is not loaded, just return EXPRESSION."
   (if (fboundp 'haskell-mode)
+      ;; From https://github.com/lunaryorn/ansible-doc.el/blob/master/ansible-doc.el#L211
+      ;; See also http://emacs.stackexchange.com/a/5408/227
       (with-temp-buffer
-        (let ((haskell-mode-hook nil)) ;; to keep switching mode cheap
+        (insert expression)
+        (delay-mode-hooks
           (haskell-mode)
-          (insert expression)
-          (font-lock-ensure)
-          (buffer-string)))
+          (font-lock-mode))
+        (font-lock-ensure)
+        (buffer-string))
     expression))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The current `dante-fontify-expression` ignores only `haskell-mode-hook`. The `prog-mode-hook` and any other hooks of parent modes are still loaded. I have added a few functions to `prog-mode-hook`, like `whitespace-mode`. So the results of `dante-info` look weird (see the picture below).

In this commit, the function ignores all mode hooks with `delay-mode-hook`. (See http://emacs.stackexchange.com/a/5408/227.)

`dante-info` before this commit:
![](https://i.imgur.com/6QTKNlu.png)

`dante-info` after this commit:
![](https://i.imgur.com/MlE2gLs.png)

BTW, thanks for this awesome package!