### PR TITLE
Make dante-company interactive

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -351,6 +351,7 @@ CHECKER and BUFFER are added if the error is in TEMP-FILE."
 (defun dante-company (command &optional arg &rest _ignored)
   "Company backend for dante.
 See ``company-backends'' for the meaning of COMMAND and _ARGS."
+  (interactive (list 'interactive))
   (let ((prefix )) ;; todo: pref len
     (cl-case command
       (interactive (company-begin-backend 'dante-company))


### PR DESCRIPTION
Right now we cannot call `dante-company` through `M-x` or a key binding to manually start this backend. So I think it might be useful to make it an interactive function.

Thanks!