### PR TITLE
Make buffer created by  dante-buffer-create read only.

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -681,6 +681,7 @@ Process state change: " change "
       (cd root)
       (fundamental-mode) ;; this has several effects, including resetting the local variables
       (buffer-disable-undo)
+      (setq-local buffer-read-only t)
       (current-buffer))))
 
 (defun dante-set-state (state)


### PR DESCRIPTION
There does not seem to be any reason that the buffer created by the function `dante-buffer-create` be writeable. I think this is a good simple addition to dante.