### PR TITLE
Support flycheck's ability to show "other file" errors

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -336,8 +336,10 @@ CHECKER and BUFFER are added if the error is in TEMP-FILE."
       ;; FIXME: sometimes the "error type" contains the actual error too.
       (flycheck-error-new-at (car location) (cadr location) type (concat err-type "\n" (s-trim-right msg))
                              :checker checker
-                             :buffer (when (string= temp-file file) buffer)
-                             :filename (dante-buffer-file-name buffer)))))
+                             :buffer buffer
+                             :filename (if (string= temp-file file)
+                                           (dante-buffer-file-name buffer)
+                                         file)))))
 
 (defun dante-parse-error-location (string)
   "Parse the line/col numbers from the error in STRING."


### PR DESCRIPTION
Dante's flychecker currently reports "no errors" in the case where a module cannot even be compiled because it depends on another broken source file. This leads to mistrust of the checker because clearly-invalid syntax can appear to be considered valid.

For a while now Flycheck has had a mechanism for allowing such "upstream" errors to be nominally reported in the current buffer (on the first line) if they are at least
`flycheck-relevant-error-other-file-minimum-level`. All that is necessary for checkers to support this is for them to parse and return errors for the current buffer where the `:filename` is a different file.

This commit makes such a (minimal) change to the Dante checker, bringing its behaviour into line with comparable checkers such as the Elm and Intero checkers.

(Note that if they prefer, users can disable "other file" errors by setting the above variable to nil.)
