### PR TITLE
Don't complete inside comments, which allows haskell-mode to complete pragmas

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -365,6 +365,10 @@ CHECKER and BUFFER are added if the error is in TEMP-FILE."
            (common (nth 2 (read (concat "(" (car lines) ")")))))
       (--map (replace-regexp-in-string "\\\"" "" (concat common it)) (cdr lines)))))
 
+(defun dante--in-a-comment ()
+  "Return non-nil if point is in a comment."
+  (nth 4 (syntax-ppss)))
+
 (declare-function company-begin-backend 'company)
 
 (defun dante-company (command &optional arg &rest _ignored)
@@ -374,7 +378,7 @@ See ``company-backends'' for the meaning of COMMAND, ARG and _IGNORED."
   (cl-case command
     (interactive (company-begin-backend 'dante-company))
     (sorted t)
-    (prefix (when (and dante-mode (dante-ident-pos-at-point))
+    (prefix (when (and dante-mode (not (dante--in-a-comment)) (dante-ident-pos-at-point))
               (let* ((id-start (car (dante-ident-pos-at-point)))
                      (_ (save-excursion (re-search-backward "import[\t ]*" (line-beginning-position) t)))
                      (import-end (match-end 0))


### PR DESCRIPTION
If `dante-company` declines to perform completions, then subsequent company backends can take their turn. This includes the standard `company-capf` backend which checks `completion-at-point-functions`: haskell-mode provides such functions for completing LANGUAGE and other
pragmas.

This change makes Dante's company backend decline to complete inside comments, which tackles the specific case of pragma completion as requested in https://github.com/jyp/dante/issues/37 but without adding functionality to Dante itself.

Dante should arguably not complete inside a string either, but I have not implemented that here. (One would check for `(nth 4 (syntax-ppss))`.)