### PR TITLE
Dante can show type signatures in minibuffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -151,4 +151,4 @@ To the best of my knowledge, here is how Dante compares with Intero:
 - With Dante, Flychecking is optional (yet recommended), whereas
   Intero demands that you flycheck your code.
 - Dante has has a different approach to Haskell evaluation
-- Dante offers no support for eldoc, nor Hoogle.
+- Dante offers no support for eldoc (but can show type signatures in the minibuffer by modifying the variable: dante-tap-type-time), nor Hoogle.


### PR DESCRIPTION
No eldoc support was a deal breaker for me, but then I discovered that you can actually get the same advantages offered by eldoc by modifying dante-tap-type-time. I think this should be mentioned in the comparison