### PR TITLE
Reject newline match in module names

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -588,7 +588,7 @@ ACC umulate input and ERR-MSGS."
                   "^Ok, modules loaded:[ ]*\\([^\n ]*\\)\\( (.*)\\)?\."
                   "^Ok, .*modules loaded." ;; .* stands for a number in english (two, three, ...) (GHC 8.2)
                   "^Ok, one module loaded."))
-        (progress "^\\[\\([0-9]*\\) of \\([0-9]*\\)\\] Compiling \\([^ ]*\\).*")
+        (progress "^\\[\\([0-9]*\\) of \\([0-9]*\\)\\] Compiling \\([^ \n]*\\).*")
         (err-regexp "^\\([A-Z]?:?[^ \n:][^:\n\r]+\\):\\([0-9()-:]+\\): \\(.*\\)\n\\(\\([ ]+.*\n\\)*\\)")
         (result nil))
     (while (not result)


### PR DESCRIPTION
On my GHCi interpreter, the “Compiling \<module\>” notification isn’t always followed by some status message, i.e. not always of the form e.g. `[1 of 1] Compiling Lib [flags changed]`. For example,

```
*Lib> :r
[1 of 1] Compiling Lib

<dir_name>/Lib.hs:15:3: error:
    parse error (possibly incorrect indentation or mismatched brackets)
   |
15 |   Right rel <- withTransaction dbconn $ do
   |   ^
Failed, no modules loaded.
```

Without rejecting the newline match, the progress regex (`^\\[\\([0-9]*\\) of \\([0-9]*\\)\\] Compiling \\([^ ]*\\).*`) will thus match the next two lines, i.e. the 3rd capture group will match

```
Lib

<dir_name>/Lib.hs:15:3:
```
As a result, the error message is gone, and flycheck reports no errors.
