### PR TITLE
Set up working directory for the checker

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -152,6 +152,10 @@ otherwise search for project root using
   (or dante-project-root
       (progn (dante-initialize-method) dante-project-root)))
 
+(defun dante-checker-working-directory (checker)
+  "Get the directory to run checker in."
+  (declare (ignore checker))
+  (dante-project-root))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Session-local variables. These are set *IN THE GHCi INTERACTION BUFFER*
@@ -329,7 +333,8 @@ and over."
 process."
   :start 'dante-check
   :predicate (lambda () dante-mode)
-  :modes '(haskell-mode literate-haskell-mode))
+  :modes '(haskell-mode literate-haskell-mode)
+  :working-directory #'dante-checker-working-directory)
 
 (add-to-list 'flycheck-checkers 'haskell-dante)
 


### PR DESCRIPTION
This helps flycheck to resolve relative file names in errors messages. When dependencies of current module have errors they get reported to flycheck but paths are typically relative to the cabal file, at least for `cabal new-*` set of checkers. I think it's unlikely that for other checkers any relative paths would be reported relative to the current module being edited so the fix shoul be reasonable, but I'm not sure whether my fix is good enough for nix-based checkers.