### PR TITLE
Clean up temporary file names in error message body

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -344,7 +344,10 @@ CHECKER and BUFFER are added if the error is in TEMP-FILE."
                   (t 'error)))
            (location (dante-parse-error-location location-raw)))
       ;; FIXME: sometimes the "error type" contains the actual error too.
-      (flycheck-error-new-at (car location) (cadr location) type (concat err-type "\n" (s-trim-right msg))
+      (flycheck-error-new-at (car location) (cadr location) type
+                             (replace-regexp-in-string (regexp-quote temp-file)
+                                                       (dante-buffer-file-name buffer)
+                                                       (concat fixed-err-type "\n" (s-trim-right msg)))
                              :checker checker
                              :buffer buffer
                              :filename (if (string= temp-file file)


### PR DESCRIPTION
Sometimes error message contain paths to the file being checked, e.g. /tmp/tmp/Tests.hs within

```
error: [-Wdeferred-type-errors]
    • Occurs check: cannot construct the infinite type: t ~ t -> Int
    • In the first argument of ‘d’, namely ‘d’
      In the second argument of ‘(*)’, namely ‘d d’
      In the second argument of ‘(+)’, namely ‘c * d d’
    • Relevant bindings include
        d :: t -> Int (bound at /tmp/tmp/Test.hs:33:14)
        go :: Int -> Int -> Int -> (t -> Int) -> Int
          (bound at /tmp/tmp/Test.hs:33:5)
```

I think it's good idea to have the paths point to the original file rather than a temporary one.