### PR TITLE
Fix error which breaks byte compilation and runtime

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -485,7 +485,7 @@ On Windows, forward slashes are changed to backslashes and the
 drive letter is capitalized."
   (let ((standard-path (convert-standard-filename path)))
     (if (eq system-type 'windows-nt)
-        (dante-capitalize-drive-letter (s-replace "/" "\\"))
+        (dante-capitalize-drive-letter (s-replace "/" "\\" standard-path))
       standard-path)))
 
 (defun dante-capitalize-drive-letter (path)


### PR DESCRIPTION
Found that the latest Dante doesn't byte-compile due to an argument number mismatch, and this fix is what I expect the offending piece of code should be.