### PR TITLE
Emphasized dante-tap-type-time in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -115,6 +115,8 @@ change. With Emacs 26:
 (setq auto-save-visited-interval 1)
 #+END_SRC
 
+If you want to see type of whatever is under the cursor at the moment as you move the cursor around, live, you can set `dante-tap-type-time` variable to number of seconds after which type information will appear in the minibuffer.
+
 
 *** Using dante + hlint
 


### PR DESCRIPTION
I think it is a really cool feature, but it is really hard to find out about it, you have to end up reading the very last sentence in the README, and it is kind of mentioned as a side note. Therefore I tried to put a mention of it on more prominent place.