### PR TITLE
Use "cabal repl" instead of "cabal v1-repl" for bare-cabal

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -115,7 +115,7 @@ will be in different GHCi sessions."
     (nix-ghci ,(lambda (d) (directory-files d t "shell.nix\\|default.nix")) ("nix-shell" "--pure" "--run" "ghci"))
     (stack "stack.yaml" ("stack" "repl" dante-target))
     (mafia "mafia" ("mafia" "repl" dante-target))
-    (bare-cabal ,(lambda (d) (directory-files d t "..cabal$")) ("cabal" "v1-repl" dante-target "--builddir=dist/dante"))
+    (bare-cabal ,(lambda (d) (directory-files d t "..cabal$")) ("cabal" "repl" dante-target "--builddir=dist/dante"))
     (bare-ghci ,(lambda (_) t) ("ghci")))
 "How to automatically locate project roots and launch GHCi.
 This is an alist from method name to a pair of


### PR DESCRIPTION
Partially reverts 7411904bfbde25cdb986e001ec682593dcb7c5e3