### PR TITLE
address usage of obsolete literate-haskell-mode

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -333,7 +333,7 @@ and over."
 process."
   :start 'dante-check
   :predicate (lambda () dante-mode)
-  :modes '(haskell-mode literate-haskell-mode)
+  :modes '(haskell-mode haskell-literate-mode)
   :working-directory (lambda (_checker) (dante-project-root)))
 
 (add-to-list 'flycheck-checkers 'haskell-dante)


### PR DESCRIPTION
It seems that haskell-mode has [made the `literate-haskell-mode` name obsolete
and aliased it to `haskell-literate-mode`](https://github.com/haskell/haskell-mode/blob/master/haskell-mode.el#L1001):

```elisp
(define-obsolete-function-alias 'literate-haskell-mode 'haskell-literate-mode "2020-04")
``` 

The alias seems to work for the most part, but doesn't seem to work with
flycheck checkers.  So this commit changes the name to the new name for the one
place Dante references it.