### PR TITLE
Use :load! and :reload! instead of :l! :r!

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -326,8 +326,8 @@ and over."
       (lcr-call dante-async-call (if interpret ":set -fbyte-code" ":set -fobject-code"))
       (with-current-buffer buffer
         (setq-local dante-status 'loading)
-        (dante-async-write (if same-target ":r!"
-                             (concat ":l! " (if interpret "*" "") (dante-local-name fname))))
+        (dante-async-write (if same-target ":reload!"
+                             (concat ":load! " (if interpret "*" "") (dante-local-name fname))))
         (cl-destructuring-bind (_status err-messages _loaded-modules)
             (lcr-call dante-load-loop "" nil err-fn)
           (setq dante-loaded-file src-fname)


### PR DESCRIPTION
On older GHCs (e.g. 8.8.4) shortcuts with '!' does not work
``` 
$ ghci
GHCi, version 8.8.4: https://www.haskell.org/ghc/  :? for help
Prelude> :r!
unknown command ':r!'
use :? for help.
Prelude> :reload!
Ok, no modules loaded.
```