### PR TITLE
Ignore GHC error codes

### DIFF
--- a/dante.el
+++ b/dante.el
@@ -361,7 +361,7 @@ process."
 (add-to-list 'flycheck-checkers 'haskell-dante)
 
 (defcustom dante-flycheck-types
-  '(("^warning: \\[-W\\(typed-holes\\|deferred-\\(type-errors\\|out-of-scope-variables\\)\\)\\]" . error)
+  '(("^warning:\\(?: \\[GHC-[0-9]+\\]\\)? \\[-W\\(?:typed-holes\\|deferred-\\(?:type-errors\\|out-of-scope-variables\\)\\)\\]" . error)
     ("^warning" . warning)
     ("^splicing " . nil)
     ("" . error))


### PR DESCRIPTION
So that regexp continues to work with newer GHCs.